### PR TITLE
Fix error "[9] System error: not a directory"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ logstash:
 kibana:
   build: kibana/
   volumes:
-    - ./kibana/config/kibana.yml:/opt/kibana/config/kibana.yml
+    - ./kibana/config/:/opt/kibana/config/
   ports:
     - "5601:5601"
   links:


### PR DESCRIPTION
When starting the stack `with docker-compose up`, it gives out the error:

```
ERROR: Cannot start container e032695b38cdcd1c72597004f2369a7127b8233c9ecc2320c3b2bbd10209654b: [9] System error: not a directory
```