### PR TITLE
Feature: allow logstash plugin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ logstash:
 To add plugins to logstash you have to:
 
 1. Add a RUN statement to the `logstash/Dockerfile` (ex. `RUN logstash-plugin install logstash-filter-json`)
-2. Add the associated plugin code to the `logstash/config/logstash.conf` file
+2. Add the associated plugin code configuration to the `logstash/config/logstash.conf` file
 
 ## How can I enable a remote JMX connection to Logstash?
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you want to override the default configuration, add the *LS_HEAP_SIZE* enviro
 
 ```yml
 logstash:
-  image: logstash:latest
+  build: logstash/
   command: logstash -f /etc/logstash/conf.d/logstash.conf
   volumes:
     - ./logstash/config:/etc/logstash/conf.d
@@ -107,6 +107,13 @@ logstash:
     - LS_HEAP_SIZE=2048m
 ```
 
+## How can I add Logstash plugins? ##
+
+To add plugins to logstash you have to:
+
+1. Add a RUN statement to the `logstash/Dockerfile` (ex. `RUN logstash-plugin install logstash-filter-json`)
+2. Add the associated plugin code to the `logstash/config/logstash.conf` file
+
 ## How can I enable a remote JMX connection to Logstash?
 
 As for the Java heap memory, another environment variable allows to specify JAVA_OPTS used by Logstash. You'll need to specify the appropriate options to enable JMX and map the JMX port on the docker host.
@@ -115,7 +122,7 @@ Update the container in the `docker-compose.yml` to add the *LS_JAVA_OPTS* envir
 
 ```yml
 logstash:
-  image: logstash:latest
+  build: logstash/
   command: logstash -f /etc/logstash/conf.d/logstash.conf
   volumes:
     - ./logstash/config:/etc/logstash/conf.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ elasticsearch:
   ports:
     - "9200:9200"
     - "9300:9300"
+
 logstash:
-  image: logstash:latest
+  build: logstash/
   command: logstash -f /etc/logstash/conf.d/logstash.conf
   volumes:
     - ./logstash/config:/etc/logstash/conf.d

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,0 +1,1 @@
+FROM logstash:latest

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,1 +1,4 @@
 FROM logstash:latest
+
+# Install plugins
+RUN logstash-plugin install logstash-filter-json

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,4 +1,4 @@
 FROM logstash:latest
 
-# Install plugins
-RUN logstash-plugin install logstash-filter-json
+# Add your logstash plugins setup here
+# Example: RUN logstash-plugin install logstash-filter-json 

--- a/logstash/config/logstash.conf
+++ b/logstash/config/logstash.conf
@@ -4,7 +4,7 @@ input {
 	}
 }
 
-## Add your filters here
+## Add your filters / logstash plugins configuration here
 
 output {
 	elasticsearch {

--- a/logstash/config/logstash.conf
+++ b/logstash/config/logstash.conf
@@ -6,6 +6,13 @@ input {
 
 ## Add your filters here
 
+# Added a default json filter for parsing the "message" field
+filter {
+    json {
+        source => "message"
+    }
+}
+
 output {
 	elasticsearch {
 		hosts => "elasticsearch:9200"

--- a/logstash/config/logstash.conf
+++ b/logstash/config/logstash.conf
@@ -6,13 +6,6 @@ input {
 
 ## Add your filters here
 
-# Added a default json filter for parsing the "message" field
-filter {
-    json {
-        source => "message"
-    }
-}
-
 output {
 	elasticsearch {
 		hosts => "elasticsearch:9200"


### PR DESCRIPTION
I wasn't able to figure out another way to install logstash plugins so I created a docker build script that allows for adding plugins.

I needed to add the logstash-filter-json plugin to parse out my "message" but I could see where having this as a default for everyone would not work (ie. if they save xml in their message)