### PR TITLE
Fix line endings issue of shell script files on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf


### PR DESCRIPTION
This should fix #36.