### PR TITLE
Upgrade to version 2 of the Docker Compose format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,28 @@
-elasticsearch:
-  image: elasticsearch:latest
-  command: elasticsearch -Des.network.host=0.0.0.0
-  ports:
-    - "9200:9200"
-    - "9300:9300"
+version: '2'
+services:
+    elasticsearch:
+        image: elasticsearch:latest
+        command: elasticsearch -Des.network.host=0.0.0.0
+        ports:
+        - "9200:9200"
+        - "9300:9300"
 
-logstash:
-  build: logstash/
-  command: logstash -f /etc/logstash/conf.d/logstash.conf
-  volumes:
-    - ./logstash/config:/etc/logstash/conf.d
-  ports:
-    - "5000:5000"
-  links:
-    - elasticsearch
-kibana:
-  build: kibana/
-  volumes:
-    - ./kibana/config/:/opt/kibana/config/
-  ports:
-    - "5601:5601"
-  links:
-    - elasticsearch
+    logstash:
+        build: logstash/
+        command: logstash -f /etc/logstash/conf.d/logstash.conf
+        volumes:
+        - ./logstash/config:/etc/logstash/conf.d
+        ports:
+        - "5000:5000"
+        links:
+        - elasticsearch
+
+    kibana:
+        build: kibana/
+        volumes:
+        - ./kibana/config/:/opt/kibana/config/
+        ports:
+        - "5601:5601"
+        links:
+        - elasticsearch
+


### PR DESCRIPTION
I've modified the compose file to use the new version 2 format.  I've tested it and the containers still come up and function as expected.

Thanks,
Ron

ps. 

Thanks for setting up the ELK stack.  Saved me having to figure everything out on my own.