### PR TITLE
Use depends_on dependency container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - "5000:5000"
     networks:
       - docker_elk
+    depends_on:
+      - elasticsearch
   kibana:
     build: kibana/
     volumes:
@@ -27,6 +29,8 @@ services:
       - "5601:5601"
     networks:
       - docker_elk
+    depends_on:
+      - elasticsearch
 
 networks:
   docker_elk:

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,5 @@
 FROM kibana:5
 
-# RUN apt-get update && RUN apt-get install -y netcat bzip2
-
 COPY entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,3 +1,1 @@
 FROM kibana:5
-
-CMD ["/tmp/entrypoint.sh"]

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,6 +1,3 @@
 FROM kibana:5
 
-COPY entrypoint.sh /tmp/entrypoint.sh
-RUN chmod +x /tmp/entrypoint.sh
-
 CMD ["/tmp/entrypoint.sh"]

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,6 +1,6 @@
 FROM kibana:5
 
-RUN apt-get update && apt-get install -y netcat bzip2
+# RUN apt-get update && RUN apt-get install -y netcat bzip2
 
 COPY entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh

--- a/kibana/entrypoint.sh
+++ b/kibana/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Starting Kibana"
-exec kibana

--- a/kibana/entrypoint.sh
+++ b/kibana/entrypoint.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
 
-# Wait for the Elasticsearch container to be ready before starting Kibana.
-echo "Stalling for Elasticsearch"
-while true; do
-    nc -q 1 elasticsearch 9200 2>/dev/null && break
-done
-
 echo "Starting Kibana"
 exec kibana


### PR DESCRIPTION
add depends_on to kibana and logstash on docker-compose.yml to prevent having to install NC and not have to keep checking for ES to start as the container will start after. 