### PR TITLE
Add note for max_map_count on Docker for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ Based on the official images:
 
 You need to increase `max_map_count` on your Docker host:
 
+### Linux
 ```bash
 $ sudo sysctl -w vm.max_map_count=262144
 ```
 
+### Mac (Docker for Mac)
+```bash
+$ screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
+```
+Log in with root and no password
+```bash
+$ sysctl -w vm.max_map_count=262144
+```
 ## SELinux
 
 On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux into Permissive mode in order for docker-elk to start properly.

--- a/README.md
+++ b/README.md
@@ -26,23 +26,13 @@ Based on the official images:
 2. Install [Docker-compose](http://docs.docker.com/compose/install/) **version >= 1.6**.
 3. Clone this repository
 
-## Increase max_map_count on your host (Linux)
+## Increase max_map_count on your host
 
-You need to increase `max_map_count` on your Docker host:
+You need to increase `max_map_count` on your Docker host.
+To do this follow the recommended instructions within the elastic documentation:
 
-### Linux
-```bash
-$ sudo sysctl -w vm.max_map_count=262144
-```
+https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode
 
-### Mac (Docker for Mac)
-```bash
-$ screen ~/Library/Containers/com.docker.docker/Data/com.docker.driver.amd64-linux/tty
-```
-Log in with root and no password
-```bash
-$ sysctl -w vm.max_map_count=262144
-```
 ## SELinux
 
 On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux into Permissive mode in order for docker-elk to start properly.


### PR DESCRIPTION
Add note for using it running Docker for Mac.
max_map_count must be set within the xhyve virtual machine