### PR TITLE
Update Searchguard to 5.2.2

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -6,7 +6,7 @@ COPY bin/ bin/
 
 # Add your elasticsearch plugins setup here
 # Example: RUN elasticsearch-plugin install analysis-icu
-RUN elasticsearch-plugin install --batch com.floragunn:search-guard-5:5.2.1-11 \
+RUN elasticsearch-plugin install --batch com.floragunn:search-guard-5:5.2.2-11 \
 	&& chmod +x \
 		plugins/search-guard-5/tools/hash.sh \
 		plugins/search-guard-5/tools/sgadmin.sh

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -3,4 +3,4 @@ FROM docker.elastic.co/kibana/kibana:5.2.2
 
 # Add your kibana plugins setup here
 # Example: RUN kibana-plugin install <name|url>
-RUN kibana-plugin install https://github.com/floragunncom/search-guard-kibana-plugin/releases/download/v5.2.1-1/searchguard-kibana-5.2.1-1.zip
+RUN kibana-plugin install https://github.com/floragunncom/search-guard-kibana-plugin/releases/download/v5.2.2-1/searchguard-kibana-5.2.2-1.zip


### PR DESCRIPTION
I wasn't able to start it from the searchguard branch due to errors saying that the search-guard plugin is not compatible with the installed elasticsearch version.
