### PR TITLE
Add Logspout functionality for out-of-the-box Docker logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![Join the chat at https://gitter.im/deviantony/docker-elk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deviantony/docker-elk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Run the latest version of the ELK (Elasticsearch, Logstash, Kibana) stack with Docker and Docker-compose.
+Run the latest version of the ELK (Elasticsearch, Logstash, Kibana) stack with Docker and Docker Compose.
 
-It will give you the ability to analyze any data set by using the searching/aggregation capabilities of Elasticsearch and the visualization power of Kibana.
+It will give you the ability to analyze any data set by using the searching/aggregation capabilities of Elasticsearch
+and the visualization power of Kibana.
 
-Based on the official images:
+Based on the official Docker images:
 
 * [elasticsearch](https://github.com/elastic/elasticsearch-docker)
 * [logstash](https://github.com/elastic/logstash-docker)
@@ -18,26 +19,51 @@ Based on the official images:
 * ELK 5 in Vagrant: https://github.com/deviantony/docker-elk/tree/vagrant
 * ELK 5 with Search Guard: https://github.com/deviantony/docker-elk/tree/searchguard
 
-# Requirements
+## Contents
 
-## Setup
+1. [Requirements](#requirements)
+   * [Host setup](#host-setup)
+   * [SELinux](#selinux)
+2. [Getting started](#getting-started)
+   * [Bringing up the stack](#bringing-up-the-stack)
+   * [Initial setup](#initial-setup)
+3. [Configuration](#configuration)
+   * [How can I tune the Kibana configuration?](#how-can-i-tune-the-kibana-configuration)
+   * [How can I tune the Logstash configuration?](#how-can-i-tune-the-logstash-configuration)
+   * [How can I tune the Elasticsearch configuration?](#how-can-i-tune-the-elasticsearch-configuration)
+   * [How can I scale out the Elasticsearch cluster?](#how-can-i-scale-up-the-elasticsearch-cluster)
+4. [Storage](#storage)
+   * [How can I persist Elasticsearch data?](#how-can-i-persist-elasticsearch-data)
+5. [Extensibility](#extensibility)
+   * [How can I add plugins?](#how-can-i-add-plugins)
+   * [How can I enable the provided extensions?](#how-can-i-enable-the-provided-extensions)
+6. [JVM tuning](#jvm-tuning)
+   * [How can I specify the amount of memory used by a service?](#how-can-i-specify-the-amount-of-memory-used-by-a-service)
+   * [How can I enable a remote JMX connection to a service?](#how-can-i-enable-a-remote-jmx-connection-to-a-service)
 
-1. Install [Docker](http://docker.io).
-2. Install [Docker-compose](http://docs.docker.com/compose/install/) **version >= 1.6**.
+## Requirements
+
+### Host setup
+
+1. Install [Docker](https://www.docker.com/community-edition#/download) version **1.10.0+**
+2. Install [Docker Compose](https://docs.docker.com/compose/install/) version **1.6.0+**
 3. Clone this repository
 
-## SELinux
+### SELinux
 
-On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux into Permissive mode in order for docker-elk to start properly.
-For example on Redhat and CentOS, the following will apply the proper context:
+On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux
+into Permissive mode in order for docker-elk to start properly. For example on Redhat and CentOS, the following will
+apply the proper context:
 
 ```bash
 $ chcon -R system_u:object_r:admin_home_t:s0 docker-elk/
 ```
 
-# Usage
+## Usage
 
-Start the ELK stack using *docker-compose*:
+### Bringing up the stack
+
+Start the ELK stack using `docker-compose`:
 
 ```bash
 $ docker-compose up
@@ -49,17 +75,8 @@ You can also choose to run it in background (detached mode):
 $ docker-compose up -d
 ```
 
-Now that the stack is running, you'll want to inject logs in it. The shipped Logstash configuration allows you to send content via TCP:
-
-```bash
-$ nc localhost 5000 < /path/to/logfile.log
-```
-
-And then access Kibana UI by hitting [http://localhost:5601](http://localhost:5601) with a web browser.
-
-*NOTE*: You'll need to inject data into Logstash before being able to configure a Logstash index pattern in Kibana. Then all you should have to do is to hit the create button.
-
-Refer to [Connect Kibana with Elasticsearch](https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html) for detailed instructions about the index pattern configuration.
+Give Elasticsearch about a minute to initialize, then access the Kibana web UI by hitting
+[http://localhost:5601](http://localhost:5601) with a web browser.
 
 By default, the stack exposes the following ports:
 * 5000: Logstash TCP input.
@@ -67,27 +84,72 @@ By default, the stack exposes the following ports:
 * 9300: Elasticsearch TCP transport
 * 5601: Kibana
 
-*WARNING*: If you're using *boot2docker*, you must access it via the *boot2docker* IP address instead of *localhost*.
+**WARNING**: If you're using `boot2docker`, you must access it via the `boot2docker` IP address instead of `localhost`.
 
-*WARNING*: If you're using *Docker Toolbox*, you must access it via the *docker-machine* IP address instead of *localhost*.
+**WARNING**: If you're using *Docker Toolbox*, you must access it via the `docker-machine` IP address instead of
+`localhost`.
 
-# Configuration
+Now that the stack is running, you will want to inject some log entries. The shipped Logstash configuration allows you
+to send content via TCP:
 
-*NOTE*: Configuration is not dynamically reloaded, you will need to restart the stack after any change in the configuration of a component.
+```bash
+$ nc localhost 5000 < /path/to/logfile.log
+```
 
-## How can I tune the Kibana configuration?
+## Initial setup
+
+### Default Kibana index pattern creation
+
+When Kibana launches for the first time, it is not configured with any index pattern.
+
+#### Via the Kibana web UI
+
+**NOTE**: You need to inject data into Logstash before being able to configure a Logstash index pattern via the Kibana web
+UI. Then all you have to do is hit the *Create* button.
+
+Refer to [Connect Kibana with
+Elasticsearch](https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html) for detailed instructions
+about the index pattern configuration.
+
+#### On the command line
+
+Run this command to create a Logstash index pattern:
+
+```bash
+$ curl -XPUT -D- 'http://localhost:9200/.kibana/index-pattern/logstash-*' \
+    -H 'Content-Type: application/json' \
+    -d '{"title" : "logstash-*", "timeFieldName": "@timestamp", "notExpandable": true}'
+```
+
+This command will mark the Logstash index pattern as the default index pattern:
+
+```bash
+$ curl -XPUT -D- 'http://localhost:9200/.kibana/config/5.4.1' \
+    -H 'Content-Type: application/json' \
+    -d '{"defaultIndex": "logstash-*"}'
+```
+
+## Configuration
+
+**NOTE**: Configuration is not dynamically reloaded, you will need to restart the stack after any change in the
+configuration of a component.
+
+### How can I tune the Kibana configuration?
 
 The Kibana default configuration is stored in `kibana/config/kibana.yml`.
 
 It is also possible to map the entire `config` directory instead of a single file.
 
-## How can I tune the Logstash configuration?
+### How can I tune the Logstash configuration?
 
 The Logstash configuration is stored in `logstash/config/logstash.yml`.
 
-It is also possible to map the entire `config` directory instead of a single file, however you must be aware that Logstash will be expecting a [`log4j2.properties`](https://github.com/elastic/logstash-docker/tree/master/build/logstash/config) file for its own logging.
+It is also possible to map the entire `config` directory instead of a single file, however you must be aware that
+Logstash will be expecting a
+[`log4j2.properties`](https://github.com/elastic/logstash-docker/tree/master/build/logstash/config) file for its own
+logging.
 
-## How can I tune the Elasticsearch configuration?
+### How can I tune the Elasticsearch configuration?
 
 The Elasticsearch configuration is stored in `elasticsearch/config/elasticsearch.yml`.
 
@@ -95,106 +157,93 @@ You can also specify the options you want to override directly via environment v
 
 ```yml
 elasticsearch:
-  build: elasticsearch/
-  ports:
-    - "9200:9200"
-    - "9300:9300"
+
   environment:
-    ES_JAVA_OPTS: "-Xmx256m -Xms256m"
     network.host: "_non_loopback_"
     cluster.name: "my-cluster"
-  networks:
-    - elk
 ```
 
-## How can I scale up the Elasticsearch cluster?
+### How can I scale out the Elasticsearch cluster?
 
-Follow the instructions from the Wiki: [Scaling up Elasticsearch](https://github.com/deviantony/docker-elk/wiki/Elasticsearch-cluster)
+Follow the instructions from the Wiki: [Scaling out
+Elasticsearch](https://github.com/deviantony/docker-elk/wiki/Elasticsearch-cluster)
 
-# Storage
+## Storage
 
-## How can I persist Elasticsearch data?
+### How can I persist Elasticsearch data?
 
 The data stored in Elasticsearch will be persisted after container reboot but not after container removal.
 
-In order to persist Elasticsearch data even after removing the Elasticsearch container, you'll have to mount a volume on your Docker host. Update the elasticsearch service declaration to:
+In order to persist Elasticsearch data even after removing the Elasticsearch container, you'll have to mount a volume on
+your Docker host. Update the `elasticsearch` service declaration to:
 
 ```yml
 elasticsearch:
-  build: elasticsearch/
-  ports:
-    - "9200:9200"
-    - "9300:9300"
-  environment:
-    ES_JAVA_OPTS: "-Xmx256m -Xms256m"
-    network.host: "_non_loopback_"
-    cluster.name: "my-cluster"
-  networks:
-    - elk
+
   volumes:
     - /path/to/storage:/usr/share/elasticsearch/data
 ```
 
 This will store Elasticsearch data inside `/path/to/storage`.
 
-# Extensibility
+## Extensibility
 
-## How can I add plugins?
+### How can I add plugins?
 
 To add plugins to any ELK component you have to:
 
 1. Add a `RUN` statement to the corresponding `Dockerfile` (eg. `RUN logstash-plugin install logstash-filter-json`)
 2. Add the associated plugin code configuration to the service configuration (eg. Logstash input/output)
 
-# JVM tuning
+### How can I enable the provided extensions?
 
-## How can I specify the amount of memory used by a service?
+A few extensions are available inside the [`extensions`](extensions) directory. These extensions provide features which
+are not part of the standard Elastic stack, but can be used to enrich it with extra integrations.
 
-By default, both Elasticsearch and Logstash start with [1/4 of the total host memory](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size) allocated to the JVM Heap Size.
+The documentation for these extensions is provided inside each individual subdirectory, on a per-extension basis. Some
+of them require manual changes to the default ELK configuration.
 
-The startup scripts for Elasticsearch and Logstash can append extra JVM options from the value of an environment variable, allowing the user to adjust the amount of memory that can be used by each component:
+## JVM tuning
+
+### How can I specify the amount of memory used by a service?
+
+By default, both Elasticsearch and Logstash start with [1/4 of the total host
+memory](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size) allocated to
+the JVM Heap Size.
+
+The startup scripts for Elasticsearch and Logstash can append extra JVM options from the value of an environment
+variable, allowing the user to adjust the amount of memory that can be used by each component:
 
 | Service       | Environment variable |
 |---------------|----------------------|
 | Elasticsearch | ES_JAVA_OPTS         |
 | Logstash      | LS_JAVA_OPTS         |
 
-To accomodate environments where memory is scarce (Docker for Mac has only 2 GB available by default), the Heap Size allocation is capped by default to 256MB per service in the `docker-compose.yml` file. If you want to override the default JVM configuration, edit the matching environment variable(s) in the `docker-compose.yml` file.
+To accomodate environments where memory is scarce (Docker for Mac has only 2 GB available by default), the Heap Size
+allocation is capped by default to 256MB per service in the `docker-compose.yml` file. If you want to override the
+default JVM configuration, edit the matching environment variable(s) in the `docker-compose.yml` file.
 
 For example, to increase the maximum JVM Heap Size for Logstash:
 
 ```yml
 logstash:
-  build: logstash/
-  volumes:
-    - ./logstash/pipeline:/usr/share/logstash/pipeline
-  ports:
-    - "5000:5000"
-  networks:
-    - elk
-  depends_on:
-    - elasticsearch
+
   environment:
     LS_JAVA_OPTS: "-Xmx1g -Xms1g"
 ```
 
-## How can I enable a remote JMX connection to a service?
+### How can I enable a remote JMX connection to a service?
 
-As for the Java Heap memory (see above), you can specify JVM options to enable JMX and map the JMX port on the docker host.
+As for the Java Heap memory (see above), you can specify JVM options to enable JMX and map the JMX port on the docker
+host.
 
-Update the *{ES,LS}_JAVA_OPTS* environment variable with the following content (I've mapped the JMX service on the port 18080, you can change that). Do not forget to update the *-Djava.rmi.server.hostname* option with the IP address of your Docker host (replace **DOCKER_HOST_IP**):
+Update the `{ES,LS}_JAVA_OPTS` environment variable with the following content (I've mapped the JMX service on the port
+18080, you can change that). Do not forget to update the `-Djava.rmi.server.hostname` option with the IP address of your
+Docker host (replace **DOCKER_HOST_IP**):
 
 ```yml
 logstash:
-  build: logstash/
-  volumes:
-    - ./logstash/pipeline:/usr/share/logstash/pipeline
-  ports:
-    - "5000:5000"
-  networks:
-    - elk
-  depends_on:
-    - elasticsearch
+
   environment:
     LS_JAVA_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=18080 -Dcom.sun.management.jmxremote.rmi.port=18080 -Djava.rmi.server.hostname=DOCKER_HOST_IP -Dcom.sun.management.jmxremote.local.only=false"
 ```

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,0 +1,1 @@
+Third-party extensions that enable extra integrations with the ELK stack.

--- a/extensions/logspout/Dockerfile
+++ b/extensions/logspout/Dockerfile
@@ -1,0 +1,5 @@
+# uses ONBUILD instructions described here:
+# https://github.com/gliderlabs/logspout/tree/master/custom
+
+FROM gliderlabs/logspout:master
+ENV SYSLOG_FORMAT rfc3164

--- a/extensions/logspout/README.md
+++ b/extensions/logspout/README.md
@@ -1,0 +1,28 @@
+# Logspout extension
+
+Logspout collects all Docker logs using the Docker logs API, and forwards them to Logstash without any additional
+configuration.
+
+## Usage
+
+If you want to include the Logspout extension, ensure the additional `logspout-compose.yml` file is included in the
+command line parameters:
+
+```bash
+$ docker-compose -f docker-compose.yml -f logspout-compose.yml up
+```
+
+In your Logstash pipeline configuration, enable the `udp` input and set the input codec to `json`:
+
+```
+input {
+  udp {
+    port  => 5000
+    codec => json
+  }
+}
+```
+
+## Documentation
+
+https://github.com/looplab/logspout-logstash

--- a/extensions/logspout/build.sh
+++ b/extensions/logspout/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# unmodified from:
+# https://github.com/gliderlabs/logspout/blob/67ee3831cbd0594361bb3381380c65bdbeb3c20f/custom/build.sh
+
+set -e
+apk add --update go git mercurial build-base
+mkdir -p /go/src/github.com/gliderlabs
+cp -r /src /go/src/github.com/gliderlabs/logspout
+cd /go/src/github.com/gliderlabs/logspout
+export GOPATH=/go
+go get
+go build -ldflags "-X main.Version=$1" -o /bin/logspout
+apk del go git mercurial build-base
+rm -rf /go /var/cache/apk/* /root/.glide
+
+# backwards compatibility
+ln -fs /tmp/docker.sock /var/run/docker.sock

--- a/extensions/logspout/logspout-compose.yml
+++ b/extensions/logspout/logspout-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  logspout:
+    build:
+      context: extensions/logspout
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      ROUTE_URIS: logstash://logstash:5000
+      LOGSTASH_TAGS: docker-elk
+    networks:
+      - elk
+    depends_on:
+      - logstash
+    restart: on-failure

--- a/extensions/logspout/modules.go
+++ b/extensions/logspout/modules.go
@@ -1,0 +1,9 @@
+package main
+
+// installs the Logstash adapter for Logspout, and required dependencies
+// https://github.com/looplab/logspout-logstash
+import (
+	_ "github.com/looplab/logspout-logstash"
+	_ "github.com/gliderlabs/logspout/transports/udp"
+	_ "github.com/gliderlabs/logspout/transports/tcp"
+)


### PR DESCRIPTION
(Rebased and squashed changes from #110)

Add direct link to baked configurations, for debugging purposes.
Separate Logspout service into its own `yml`
Standardize Markdown formatting for program names
Do not auto-create indexes
Remove comments & UDP input