### PR TITLE
plugin readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ To add plugins to any ELK component you have to:
 
 1. Add a `RUN` statement to the corresponding `Dockerfile` (eg. `RUN logstash-plugin install logstash-filter-json`)
 2. Add the associated plugin code configuration to the service configuration (eg. Logstash input/output)
+3. Rebuild the images using the `docker-compose build` command
 
 ### How can I enable the provided extensions?
 


### PR DESCRIPTION
I had to run "docker-compose build" after modifying Dockerfile.
Unless doing so, plugin was never added.

 And I thought adding this step will help others with limited knowledge of Docker.