### PR TITLE
docker-compose exec for searchguard initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ docker-compose up -d
 Search Guard must be initialized after Elasticsearch is started:
 
 ```bash
-$ docker exec dockerelk_elasticsearch_1 bin/init_sg.sh
+$ docker-compose exec -T elasticsearch bin/init_sg.sh
 ```
 
 _This executes sgadmin and loads the configuration from `elasticsearch/config/sg*.yml`_


### PR DESCRIPTION
`docker-compose exec` makes more sense to initialize searchguard, as all the commands using `docker-compose`.