### PR TITLE
Updated the project for supporting the latest GA version 6.0.0 OSS Edition

### DIFF
--- a/-v
+++ b/-v
@@ -1,0 +1,7 @@
+HTTP/1.1 200 OK
+kbn-name: kibana
+kbn-version: 6.0.0
+cache-control: no-cache
+Date: Fri, 17 Nov 2017 16:44:57 GMT
+Connection: keep-alive
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - docker-compose up -d
 
   # Verifications
-  - sleep 4m
+  - sleep 30
   - docker-compose logs
-  - curl --retry 10 --retry-delay 5 -v http://localhost:9200/
-  - curl --retry 10 --retry-delay 5 -v http://localhost:5601/
+  - curl --retry 10 --retry-delay 5 -D- http://localhost:9200/
+  - curl --retry 10 --retry-delay 5 -ID-v http://localhost:5601/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker ELK stack
 
 [![Join the chat at https://gitter.im/deviantony/docker-elk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deviantony/docker-elk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Elastic Stack version](https://img.shields.io/badge/ELK-6.0.0-blue.svg?style=flat)](https://github.com/deviantony/docker-elk/issues/182)
+[![Elastic Stack version](https://img.shields.io/badge/ELK-6.0.0-blue.svg?style=flat)](https://github.com/deviantony/docker-elk/issues/196)
 [![Build Status](https://api.travis-ci.org/deviantony/docker-elk.svg?branch=master)](https://travis-ci.org/deviantony/docker-elk)
 
 Run the latest version of the ELK (Elasticsearch, Logstash, Kibana) stack with Docker and Docker Compose.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can also choose to run it in background (detached mode):
 $ docker-compose up -d
 ```
 
-Give Kibana about 2 minutes to initialize, then access the Kibana web UI by hitting
+Give Kibana a few seconds to initialize, then access the Kibana web UI by hitting
 [http://localhost:5601](http://localhost:5601) with a web browser.
 
 By default, the stack exposes the following ports:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docker ELK stack
 
 [![Join the chat at https://gitter.im/deviantony/docker-elk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deviantony/docker-elk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Elastic Stack version](https://img.shields.io/badge/ELK-5.6.3-blue.svg?style=flat)](https://github.com/deviantony/docker-elk/issues/182)
+[![Elastic Stack version](https://img.shields.io/badge/ELK-6.0.0-blue.svg?style=flat)](https://github.com/deviantony/docker-elk/issues/182)
 [![Build Status](https://api.travis-ci.org/deviantony/docker-elk.svg?branch=master)](https://travis-ci.org/deviantony/docker-elk)
 
 Run the latest version of the ELK (Elasticsearch, Logstash, Kibana) stack with Docker and Docker Compose.
@@ -17,9 +17,9 @@ Based on the official Docker images:
 
 **Note**: Other branches in this project are available:
 
-* ELK 5 with X-Pack support: https://github.com/deviantony/docker-elk/tree/x-pack
-* ELK 5 in Vagrant: https://github.com/deviantony/docker-elk/tree/vagrant
-* ELK 5 with Search Guard: https://github.com/deviantony/docker-elk/tree/searchguard
+* ELK 6 with X-Pack support: https://github.com/deviantony/docker-elk/tree/x-pack
+* ELK 6 in Vagrant: https://github.com/deviantony/docker-elk/tree/vagrant
+* ELK 6 with Search Guard: https://github.com/deviantony/docker-elk/tree/searchguard
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -120,18 +120,12 @@ about the index pattern configuration.
 Run this command to create a Logstash index pattern:
 
 ```console
-$ curl -XPUT -D- 'http://localhost:9200/.kibana/index-pattern/logstash-*' \
+$ curl -XPUT -D- 'http://localhost:9200/.kibana/doc/index-pattern:docker-elk' \
     -H 'Content-Type: application/json' \
-    -d '{"title" : "logstash-*", "timeFieldName": "@timestamp", "notExpandable": true}'
+    -d '{"type": "index-pattern", "index-pattern": {"title": "logstash-*", "timeFieldName": "@timestamp"}}'
 ```
 
-This command will mark the Logstash index pattern as the default index pattern:
-
-```console
-$ curl -XPUT -D- 'http://localhost:9200/.kibana/config/5.6.3' \
-    -H 'Content-Type: application/json' \
-    -d '{"defaultIndex": "logstash-*"}'
-```
+This will automatically be marked as the default index pattern as soon as the Kibana UI is opened for the first time.
 
 ## Configuration
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -5,4 +5,3 @@ FROM docker.elastic.co/elasticsearch/elasticsearch-oss:${ELK_VERSION}
 
 # Add your elasticsearch plugins setup here
 # Example: RUN elasticsearch-plugin install analysis-icu
-RUN elasticsearch-plugin install x-pack

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/elastic/elasticsearch-docker
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.3
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0
 
 # Add your elasticsearch plugins setup here
 # Example: RUN elasticsearch-plugin install analysis-icu
+RUN elasticsearch-plugin install x-pack

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -14,13 +14,3 @@ discovery.zen.minimum_master_nodes: 1
 ## see https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
 #
 discovery.type: single-node
-
-## Disable X-Pack
-## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
-##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
-#
-xpack.monitoring.enabled: false
-xpack.ml.enabled: false
-xpack.watcher.enabled: false
-xpack.security.enabled: false
-xpack.graph.enabled: false

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -19,7 +19,8 @@ discovery.type: single-node
 ## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
 ##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
 #
-xpack.security.enabled: false
 xpack.monitoring.enabled: false
 xpack.ml.enabled: false
 xpack.watcher.enabled: false
+xpack.security.enabled: false
+xpack.graph.enabled: false

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/elastic/kibana-docker
-FROM docker.elastic.co/kibana/kibana:5.6.3
+FROM docker.elastic.co/kibana/kibana-oss:6.0.0
 
 # Add your kibana plugins setup here
 # Example: RUN kibana-plugin install <name|url>

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -5,14 +5,3 @@
 server.name: kibana
 server.host: "0"
 elasticsearch.url: http://elasticsearch:9200
-
-## Disable X-Pack
-## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
-##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
-#
-xpack.security.enabled: false
-xpack.monitoring.enabled: false
-xpack.ml.enabled: false
-xpack.graph.enabled: false
-xpack.reporting.enabled: false
-xpack.grokdebugger.enabled: false

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/elastic/logstash-docker
-FROM docker.elastic.co/logstash/logstash:5.6.3
+FROM docker.elastic.co/logstash/logstash-oss:6.0.0
 
 # Add your logstash plugins setup here
 # Example: RUN logstash-plugin install logstash-filter-json

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -4,9 +4,3 @@
 #
 http.host: "0.0.0.0"
 path.config: /usr/share/logstash/pipeline
-
-## Disable X-Pack
-## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
-##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
-#
-xpack.monitoring.enabled: false


### PR DESCRIPTION
I have updated the ELK stack using the latest OSS edition but probably it could be useful to have different branches dedicated to the OSS and Enterprise editions.

Starting from this release to disable X-Pack we need to install the plugin and the disable it using properties. For Kibana and Logstash we can remove all the properties.

Hope this helps 😄 