### PR TITLE
fixing broken compatibility with Docker < 17.03

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-ELK_VERSION=6.0.0

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Based on the official Docker images:
 6. [JVM tuning](#jvm-tuning)
    * [How can I specify the amount of memory used by a service?](#how-can-i-specify-the-amount-of-memory-used-by-a-service)
    * [How can I enable a remote JMX connection to a service?](#how-can-i-enable-a-remote-jmx-connection-to-a-service)
-7. [Updates](#updates)
-   * [Using a newer stack version](#using-a-newer-stack-version)
 
 ## Requirements
 
@@ -255,18 +253,3 @@ logstash:
   environment:
     LS_JAVA_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=18080 -Dcom.sun.management.jmxremote.rmi.port=18080 -Djava.rmi.server.hostname=DOCKER_HOST_IP -Dcom.sun.management.jmxremote.local.only=false"
 ```
-
-## Updates
-
-### Using a newer stack version
-
-To use a different Elastic Stack version than the one currently available in the repository, simply change the version
-number inside the `.env` file, and rebuild the stack with:
-
-```console
-$ docker-compose build
-$ docker-compose up
-```
-
-**NOTE**: Always pay attention to the [upgrade instructions](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html)
-for each individual component before performing a stack upgrade.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
   elasticsearch:
     build:
       context: elasticsearch/
-      args:
-        ELK_VERSION: $ELK_VERSION
     volumes:
       - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
     ports:
@@ -20,8 +18,6 @@ services:
   logstash:
     build:
       context: logstash/
-      args:
-        ELK_VERSION: $ELK_VERSION
     volumes:
       - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
       - ./logstash/pipeline:/usr/share/logstash/pipeline
@@ -37,8 +33,6 @@ services:
   kibana:
     build:
       context: kibana/
-      args:
-        ELK_VERSION: $ELK_VERSION
     volumes:
       - ./kibana/config/:/usr/share/kibana/config:ro
     ports:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,7 +1,5 @@
-ARG ELK_VERSION
-
 # https://github.com/elastic/elasticsearch-docker
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:${ELK_VERSION}
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0
 
 # Add your elasticsearch plugins setup here
 # Example: RUN elasticsearch-plugin install analysis-icu

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,5 @@
-ARG ELK_VERSION
-
 # https://github.com/elastic/kibana-docker
-FROM docker.elastic.co/kibana/kibana-oss:${ELK_VERSION}
+FROM docker.elastic.co/kibana/kibana-oss:6.0.0
 
 # Add your kibana plugins setup here
 # Example: RUN kibana-plugin install <name|url>

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,7 +1,5 @@
-ARG ELK_VERSION
-
 # https://github.com/elastic/logstash-docker
-FROM docker.elastic.co/logstash/logstash-oss:${ELK_VERSION}
+FROM docker.elastic.co/logstash/logstash-oss:6.0.0
 
 # Add your logstash plugins setup here
 # Example: RUN logstash-plugin install logstash-filter-json


### PR DESCRIPTION
Looking at lines statistics I don't think it was worth adding 😄 

Tested on 
```
[/location] # docker --version
Docker version 1.11.2, build 781516c
[/location] # docker-compose --version
docker-compose version 1.13.0, build 1719ceb
```

Ref:  #205 