### PR TITLE
WIP integrate Elasticfence plugins into ELK 5.3.1 

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,5 +1,7 @@
 # https://github.com/elastic/elasticsearch-docker
 FROM docker.elastic.co/elasticsearch/elasticsearch:5.3.1
 
+COPY config/ config/
+
 # Add your elasticsearch plugins setup here
 RUN bin/elasticsearch-plugin install https://cdn.rawgit.com/jemacom/elasticsearch-http-user-auth/5.3.1/jar/elasticfence-5.3.1-SNAPSHOT.zip?raw=true

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/elastic/elasticsearch-docker
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.3.1
 
 # Add your elasticsearch plugins setup here
-# Example: RUN elasticsearch-plugin install analysis-icu
+RUN bin/elasticsearch-plugin install https://cdn.rawgit.com/jemacom/elasticsearch-http-user-auth/5.3.1/jar/elasticfence-5.3.1-SNAPSHOT.zip?raw=true

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -13,4 +13,13 @@ discovery.zen.minimum_master_nodes: 1
 ## Use single node discovery in order to disable production mode and avoid bootstrap checks
 ## see https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
 #
-discovery.type: single-node
+#discovery.type: single-node
+
+## Disable X-Pack
+## see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
+##     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
+#
+xpack.security.enabled: false
+xpack.monitoring.enabled: false
+xpack.graph.enabled: false
+xpack.watcher.enabled: false

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -23,3 +23,5 @@ xpack.security.enabled: false
 xpack.monitoring.enabled: false
 xpack.graph.enabled: false
 xpack.watcher.enabled: false
+
+elasticfence.root.password: notastrongpassword

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/elastic/kibana-docker
-FROM docker.elastic.co/kibana/kibana-oss:6.0.0
+FROM docker.elastic.co/kibana/kibana:5.3.1
 
 # Add your kibana plugins setup here
-# Example: RUN kibana-plugin install <name|url>
+RUN kibana-plugin install https://cdn.rawgit.com/jemacom/kibana-auth-elasticfence/5.3.1/releases/kibana-auth-elasticfence-5.3.1.zip?raw=true

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/elastic/kibana-docker
 FROM docker.elastic.co/kibana/kibana:5.3.1
 
+COPY config/ config/
 # Add your kibana plugins setup here
 RUN kibana-plugin install https://cdn.rawgit.com/jemacom/kibana-auth-elasticfence/5.3.1/releases/kibana-auth-elasticfence-5.3.1.zip?raw=true

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -4,7 +4,7 @@
 #
 server.name: kibana
 server.host: "0"
-elasticsearch.url: http://elasticsearch:9200
+elasticsearch.url: http://0.0.0.0:9200
 
 xpack.security.enabled: false
 xpack.monitoring.enabled: false

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -5,3 +5,9 @@
 server.name: kibana
 server.host: "0"
 elasticsearch.url: http://elasticsearch:9200
+
+xpack.security.enabled: false
+xpack.monitoring.enabled: false
+xpack.ml.enabled: false
+xpack.graph.enabled: false
+xpack.reporting.enabled: false

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -11,3 +11,8 @@ xpack.monitoring.enabled: false
 xpack.ml.enabled: false
 xpack.graph.enabled: false
 xpack.reporting.enabled: false
+
+
+# Custom config
+elasticsearch.username: "kibanaserver"
+elasticsearch.password: "kibanaserver"

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/elastic/logstash-docker
 FROM docker.elastic.co/logstash/logstash:5.3.1
 
+COPY config/ config/
 # Add your logstash plugins setup here
 # Example: RUN logstash-plugin install logstash-filter-json

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/elastic/logstash-docker
-FROM docker.elastic.co/logstash/logstash-oss:6.0.0
+FROM docker.elastic.co/logstash/logstash:5.3.1
 
 # Add your logstash plugins setup here
 # Example: RUN logstash-plugin install logstash-filter-json

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -4,3 +4,5 @@
 #
 http.host: "0.0.0.0"
 path.config: /usr/share/logstash/pipeline
+
+xpack.monitoring.enabled: false


### PR DESCRIPTION
***NOTE:*** This is a WIP PR and it should probably merged in another branch like ```5.3.1-elasticfence``` if it's run properly and you accept to add it in the project of course.

*I opened the this PR just to reproduce the errors.*

I want to integrate [Elasticfence](https://github.com/elasticfence) into elk-docker. Since I like the project simplicity and ease of use but it was build on earlier version of ELK  stack 5.1.2 and it's now unmaintained so I did some work around to run it on ELK 5.3.1. 

Long story short I succeeded to install the required Kibana and Elasticsearch plugin into elk-docker. However I'm facing hard time to make it run properly.

Here's some logs: 
```bash
elasticsearch_1  | [2017-12-20T10:10:37,394][INFO ][o.e.t.TransportService   ] [WVnkU0c] publish_address {172.19.0.2:9300}, bound_addresses {[::]:9300}
elasticsearch_1  | [2017-12-20T10:10:37,408][INFO ][o.e.b.BootstrapChecks    ] [WVnkU0c] bound or publishing to a non-loopback or non-link-local address, enforcing bootstrap checks
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:39Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:39Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
elasticsearch_1  | [2017-12-20T10:10:40,572][INFO ][o.e.c.s.ClusterService   ] [WVnkU0c] new_master {WVnkU0c}{WVnkU0chSP2zOlMEXDvk0A}{zkldTANLTOeJiwgQs3jOuA}{172.19.0.2}{172.19.0.2:9300}, reason: zen-disco-elected-as-master ([0] nodes joined)
elasticsearch_1  | [2017-12-20T10:10:40,676][INFO ][o.e.h.n.Netty4HttpServerTransport] [WVnkU0c] publish_address {172.19.0.2:9200}, bound_addresses {[::]:9200}
elasticsearch_1  | [2017-12-20T10:10:40,699][INFO ][o.e.n.Node               ] [WVnkU0c] started
elasticsearch_1  | [2017-12-20T10:10:40,884][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:40,909][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:41,021][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:41,029][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:41,375][INFO ][o.e.l.LicenseService     ] [WVnkU0c] license [5598dc7d-68ef-4847-8f44-11f5f2fe6403] mode [trial] - valid
elasticsearch_1  | [2017-12-20T10:10:41,376][INFO ][o.e.g.GatewayService     ] [WVnkU0c] recovered [2] indices into cluster_state
elasticsearch_1  | [2017-12-20T10:10:41,406][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:41,407][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:41,410][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:41,411][WARN ][o.e.d.i.m.TypeParsers    ] field [include_in_all] is deprecated, as [_all] is deprecated, and will be disallowed in 6.0, use [copy_to] instead.
elasticsearch_1  | [2017-12-20T10:10:42,205][INFO ][o.e.c.r.a.AllocationService] [WVnkU0c] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[.kibana][0]] ...]).
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:42Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:42Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:44Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:44Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
logstash_1       | Sending Logstash's logs to /usr/share/logstash/logs which is now configured via log4j2.properties
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:47Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:47Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
logstash_1       | [2017-12-20T10:10:47,464][INFO ][logstash.outputs.elasticsearch] Elasticsearch pool URLs updated {:changes=>{:removed=>[], :added=>[http://elasticsearch:9200/]}}
logstash_1       | [2017-12-20T10:10:47,470][INFO ][logstash.outputs.elasticsearch] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://elasticsearch:9200/, :path=>"/"}
logstash_1       | [2017-12-20T10:10:47,677][WARN ][logstash.outputs.elasticsearch] Restored connection to ES instance {:url=>#<URI::HTTP:0x286f237 URL:http://elasticsearch:9200/>}
logstash_1       | [2017-12-20T10:10:47,678][INFO ][logstash.outputs.elasticsearch] Using mapping template from {:path=>nil}
logstash_1       | [2017-12-20T10:10:47,756][INFO ][logstash.outputs.elasticsearch] Attempting to install template {:manage_template=>{"template"=>"logstash-*", "version"=>50001, "settings"=>{"index.refresh_interval"=>"5s"}, "mappings"=>{"_default_"=>{"_all"=>{"enabled"=>true, "norms"=>false}, "dynamic_templates"=>[{"message_field"=>{"path_match"=>"message", "match_mapping_type"=>"string", "mapping"=>{"type"=>"text", "norms"=>false}}}, {"string_fields"=>{"match"=>"*", "match_mapping_type"=>"string", "mapping"=>{"type"=>"text", "norms"=>false, "fields"=>{"keyword"=>{"type"=>"keyword"}}}}}], "properties"=>{"@timestamp"=>{"type"=>"date", "include_in_all"=>false}, "@version"=>{"type"=>"keyword", "include_in_all"=>false}, "geoip"=>{"dynamic"=>true, "properties"=>{"ip"=>{"type"=>"ip"}, "location"=>{"type"=>"geo_point"}, "latitude"=>{"type"=>"half_float"}, "longitude"=>{"type"=>"half_float"}}}}}}}}
logstash_1       | [2017-12-20T10:10:47,769][INFO ][logstash.outputs.elasticsearch] New Elasticsearch output {:class=>"LogStash::Outputs::ElasticSearch", :hosts=>[#<URI::Generic:0x2e193eee URL://elasticsearch:9200>]}
logstash_1       | [2017-12-20T10:10:47,777][INFO ][logstash.pipeline        ] Starting pipeline {"id"=>"main", "pipeline.workers"=>4, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>5, "pipeline.max_inflight"=>500}
logstash_1       | [2017-12-20T10:10:47,802][INFO ][logstash.inputs.tcp      ] Starting tcp input listener {:address=>"0.0.0.0:5000"}
logstash_1       | [2017-12-20T10:10:47,820][INFO ][logstash.pipeline        ] Pipeline main started
logstash_1       | [2017-12-20T10:10:47,897][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:49Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:49Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:52Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:52Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:54Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:54Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:57Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"Unable to revive connection: http://0.0.0.0:9200/"}
kibana_1         | {"type":"log","@timestamp":"2017-12-20T10:10:57Z","tags":["warning","elasticsearch","admin"],"pid":12,"message":"No living connections"}
```

* I have ***Ubuntu 17.04*** on my machine.
```
$ docker version
Client:
 Version:      1.13.1
 API version:  1.26
 Go version:   go1.8.3
 Git commit:   092cba3
 Built:        Thu Oct 12 22:34:44 2017
 OS/Arch:      linux/amd64

Server:
 Version:      1.13.1
 API version:  1.26 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   092cba3
 Built:        Thu Oct 12 22:34:44 2017
 OS/Arch:      linux/amd64
 Experimental: false
```

```
$ docker-compose version
docker-compose version 1.17.0, build ac53b73
docker-py version: 2.5.1
CPython version: 2.7.13
OpenSSL version: OpenSSL 1.0.1t  3 May 2016
```

I'm not sure if those errors are related to ```docker-elk``` or they're specific to the installed plugins.
Any help on this will be really appreciated. :wink: 