### PR TITLE
Define persistent elk network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.5'
 
 services:
 
@@ -46,3 +46,4 @@ networks:
 
   elk:
     driver: bridge
+    name: elk_network


### PR DESCRIPTION
Otherwise network name is composed of the current folder name + "_elk". This could differ through various installations.