### PR TITLE
Add GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Because we focus purely on integrating the Elastic stack using Docker and not on the individual stack components themselves, we kindly ask our users to submit questions about Elastic products in the Elastic Discussion Forums @ https://discuss.elastic.co/.
+
+General questions regarding this project can be asked in the docker-elk Gitter chat room @ https://gitter.im/deviantony/docker-elk.
+-->
+
+### Problem description
+
+<!-- Be as descriptive as possible regarding the encountered issue versus the expected outcome. -->
+
+### Extra information
+
+<!-- Please include the following information in your issue report. -->
+
+#### Stack configuration
+
+<!-- Detail all performed configuration changes, including to Dockerfiles. -->
+
+#### Docker setup
+
+```
+<!-- Replace this comment with the full output of the `docker version` command. -->
+```
+
+```
+<!-- Replace this comment with the full output of the `docker-compose version` command. -->
+```
+
+#### Docker logs
+
+```
+<!-- Replace this comment with the full output of the `docker-compose logs` command. -->
+```


### PR DESCRIPTION
This template clarifies the scope of the problems we are willing to spend time solving, and provides a framework for submitting new issues with the minimum required information for reproducing.