### PR TITLE
Add APM server and APM test agent to compose file

### DIFF
--- a/extensions/apm-server/Dockerfile
+++ b/extensions/apm-server/Dockerfile
@@ -1,0 +1,3 @@
+ARG ELK_VERSION
+
+FROM docker.elastic.co/apm/apm-server:${ELK_VERSION}

--- a/extensions/apm-server/README.md
+++ b/extensions/apm-server/README.md
@@ -1,0 +1,54 @@
+# APM Server extension
+
+Adds a container for Elasticsearch APM server. Forwards caught errors and traces to Elasticsearch
+server that can be viewed in Kibana. 
+
+## Usage
+
+If you want to include the APM server, run Docker compose from the root of 
+the repository with an additional command line argument referencing the `apm-server-compose.yml` file:
+                                                                           
+```bash
+$ docker-compose -f docker-compose.yml -f extensions/apm-server/apm-server-compose.yml up
+```
+
+## Connecting an agent to APM-Server
+
+The most basic configuration to send traces to apm server. Is to specify the
+`SERVICE_NAME` and `SERVICE_URL`. Here is an example Python FLASK configuration: 
+
+```python
+import elasticapm
+from elasticapm.contrib.flask import ElasticAPM
+
+from flask import Flask
+
+app = Flask(__name__)
+app.config['ELASTIC_APM'] = {
+    # Set required service name. Allowed characters:
+    # a-z, A-Z, 0-9, -, _, and space
+    'SERVICE_NAME': 'PYTHON_FLASK_TEST_APP',
+
+    # Set custom APM Server URL (default: http://localhost:8200)
+    'SERVER_URL': 'http://apm-server:8200',
+
+    'DEBUG': True,
+}
+```
+
+More configuration setting can be found under the **Configuration**
+section for each language. Link: https://www.elastic.co/guide/en/apm/agent/index.html 
+
+## Checking Connectivity and Importing default APM Dashboards
+
+From Kibana main window press:
+
+1. `Add APM` button under Add Data to Kibana section
+2. Ignore all the install instructions and press `Check APM Server status` button.
+3. Press `Check agent status`
+4. Press `Load Kibana objects` to get the default dashboards
+5. Lastly press the `APM dashboard` to the bottom right.
+
+## APM Agent Documentation
+
+Link: https://www.elastic.co/guide/en/apm/agent/index.html

--- a/extensions/apm-server/apm-server-compose.yml
+++ b/extensions/apm-server/apm-server-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  apm-server:
+    build:
+      context: extensions/apm-server/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    volumes:
+      - ./apm-server/config/apm-server.yml:/usr/share/apm-server/config/apm-server.yml:ro
+    ports:
+      - "8200:8200"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch

--- a/extensions/apm-server/config/apm-server.yml
+++ b/extensions/apm-server/config/apm-server.yml
@@ -1,0 +1,6 @@
+apm-server:
+  host: localhost:8200
+
+output:
+  elasticsearch:
+    hosts: http://elasticsearch:9200


### PR DESCRIPTION
Unsure if this of interest to you, but was doing some prototyping with Elasticsearch APM server using your elk stack and wanted to return the favor if an APM server is wanted in the stack. 

Why:
* Adds Elasticsearch Application Performance Monitoring
* Can view application traces, errors and alerts trough Kibana

How:
* Add apm-server container to the network which will receive traffic on port 8200 and report to elastic search server at port 9200
* Add a test flask app with redis to view apm tracing