### PR TITLE
Write Curator logs to STDOUT

### DIFF
--- a/extensions/curator/config/curator.yml
+++ b/extensions/curator/config/curator.yml
@@ -20,5 +20,5 @@ client:
 
 logging:
   loglevel: DEBUG
-  logfile:  /usr/share/curator/curator.log
+  logfile:
   logformat: default


### PR DESCRIPTION
So far the included Curator configuration logs to `/usr/share/curator/curator.log`. To follow the best-practices in regards to logging inside a container, this PR proposes to log to `STDOUT`.