### PR TITLE
Make ELK image flavour configurable

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 ELK_VERSION=6.5.4
-# set to -oss if you prefer the open source license, leave empty otherwise
+# Leave blank to use the "basic" image flavours, which include X-Pack.
 # see https://www.elastic.co/subscriptions
 ELK_FLAVOUR=-oss
 

--- a/.env
+++ b/.env
@@ -5,5 +5,5 @@ ELK_VERSION=6.5.4
 #  * https://search.maven.org/search?q=g:com.floragunn%20AND%20a:search-guard-6&core=gav
 #  * https://search.maven.org/search?q=g:com.floragunn%20AND%20a:search-guard-kibana-plugin&core=gav
 #
-SG_VERSION=24.0
-SG_VERSION_KIBANA=17
+SG_VERSION=24.1
+SG_VERSION_KIBANA=18

--- a/.env
+++ b/.env
@@ -8,5 +8,5 @@ ELK_FLAVOUR=-oss
 #  * https://search.maven.org/search?q=g:com.floragunn%20AND%20a:search-guard-6&core=gav
 #  * https://search.maven.org/search?q=g:com.floragunn%20AND%20a:search-guard-kibana-plugin&core=gav
 #
-SG_VERSION=24.1
-SG_VERSION_KIBANA=18
+SG_VERSION=24.0
+SG_VERSION_KIBANA=17

--- a/.env
+++ b/.env
@@ -1,4 +1,7 @@
 ELK_VERSION=6.5.4
+# set to -oss if you prefer the open source license, leave empty otherwise
+# see https://www.elastic.co/subscriptions
+ELK_FLAVOUR=-oss
 
 # Check Search Guard versions matrix at https://docs.search-guard.com/latest/search-guard-versions
 # or the Maven Central repository:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: elasticsearch/
       args:
+        ELK_FLAVOUR: $ELK_FLAVOUR
         ELK_VERSION: $ELK_VERSION
         SG_VERSION: $SG_VERSION
     volumes:
@@ -22,6 +23,7 @@ services:
     build:
       context: logstash/
       args:
+        ELK_FLAVOUR: $ELK_FLAVOUR
         ELK_VERSION: $ELK_VERSION
     volumes:
       - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
@@ -40,6 +42,7 @@ services:
     build:
       context: kibana/
       args:
+        ELK_FLAVOUR: $ELK_FLAVOUR
         ELK_VERSION: $ELK_VERSION
         SG_VERSION_KIBANA: $SG_VERSION_KIBANA
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: elasticsearch/
       args:
-        ELK_FLAVOUR: $ELK_FLAVOUR
         ELK_VERSION: $ELK_VERSION
+        ELK_FLAVOUR: $ELK_FLAVOUR
         SG_VERSION: $SG_VERSION
     volumes:
       - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
@@ -23,8 +23,8 @@ services:
     build:
       context: logstash/
       args:
-        ELK_FLAVOUR: $ELK_FLAVOUR
         ELK_VERSION: $ELK_VERSION
+        ELK_FLAVOUR: $ELK_FLAVOUR
     volumes:
       - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
       - ./logstash/pipeline:/usr/share/logstash/pipeline:ro
@@ -42,8 +42,8 @@ services:
     build:
       context: kibana/
       args:
-        ELK_FLAVOUR: $ELK_FLAVOUR
         ELK_VERSION: $ELK_VERSION
+        ELK_FLAVOUR: $ELK_FLAVOUR
         SG_VERSION_KIBANA: $SG_VERSION_KIBANA
     volumes:
       - ./kibana/config/:/usr/share/kibana/config:ro

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELK_VERSION
 ARG ELK_FLAVOUR
 
-# https://github.com/elastic/elasticsearch-docker / https://www.docker.elastic.co/
+# https://github.com/elastic/elasticsearch-docker
 FROM docker.elastic.co/elasticsearch/elasticsearch${ELK_FLAVOUR}:${ELK_VERSION}
 
 COPY config/sg/ config/sg/

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,7 +1,8 @@
 ARG ELK_VERSION
+ARG ELK_FLAVOUR
 
-# https://github.com/elastic/elasticsearch-docker
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:${ELK_VERSION}
+# https://github.com/elastic/elasticsearch-docker / https://www.docker.elastic.co/
+FROM docker.elastic.co/elasticsearch/elasticsearch${ELK_FLAVOUR}:${ELK_VERSION}
 
 COPY config/sg/ config/sg/
 COPY bin/ bin/

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELK_VERSION
 ARG ELK_FLAVOUR
 
-# https://github.com/elastic/kibana-docker / https://www.docker.elastic.co/
+# https://github.com/elastic/kibana-docker
 FROM docker.elastic.co/kibana/kibana${ELK_FLAVOUR}:${ELK_VERSION}
 
 # Search Guard plugin

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,7 +1,8 @@
 ARG ELK_VERSION
+ARG ELK_FLAVOUR
 
-# https://github.com/elastic/kibana-docker
-FROM docker.elastic.co/kibana/kibana-oss:${ELK_VERSION}
+# https://github.com/elastic/kibana-docker / https://www.docker.elastic.co/
+FROM docker.elastic.co/kibana/kibana${ELK_FLAVOUR}:${ELK_VERSION}
 
 # Search Guard plugin
 ARG ELK_VERSION

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,7 +1,8 @@
 ARG ELK_VERSION
+ARG ELK_FLAVOUR
 
-# https://github.com/elastic/logstash-docker
-FROM docker.elastic.co/logstash/logstash-oss:${ELK_VERSION}
+# https://github.com/elastic/logstash-docker / https://www.docker.elastic.co/
+FROM docker.elastic.co/logstash/logstash${ELK_FLAVOUR}:${ELK_VERSION}
 
 # Add your logstash plugins setup here
 # Example: RUN logstash-plugin install logstash-filter-json

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELK_VERSION
 ARG ELK_FLAVOUR
 
-# https://github.com/elastic/logstash-docker / https://www.docker.elastic.co/
+# https://github.com/elastic/logstash-docker
 FROM docker.elastic.co/logstash/logstash${ELK_FLAVOUR}:${ELK_VERSION}
 
 # Add your logstash plugins setup here


### PR DESCRIPTION
This project was using hardcoded `-oss` images. Playing with subscription plan features was only possible when hacking the Dockerfiles. Thus, I made the flavour configurable.

While doing this I also bumped searchguard to latest versions (separate commit, so the other change can be cherrypicked)