### PR TITLE
Search Guard + X-Pack

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 ELK_VERSION=6.7.0
 # Leave blank to use the "basic" image flavours, which include X-Pack.
 # see https://www.elastic.co/subscriptions
-ELK_FLAVOUR=-oss
+ELK_FLAVOUR=
 
 # Check Search Guard versions matrix at https://docs.search-guard.com/latest/search-guard-versions
 # or the Maven Central repository:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 
 Run the latest version of the [Elastic stack](https://www.elastic.co/elk-stack) with Docker and Docker Compose.
 
-**Note**: This version has [Search Guard support](https://github.com/floragunncom/search-guard).
+**Note**: This version has [Search Guard support](https://github.com/floragunncom/search-guard) and 
+[X-Pack support](https://www.elastic.co/products/x-pack) with 
+[X-Packsecurity](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html) disable
+becuse it is managed by [Search Guard](https://docs.search-guard.com/latest/search-guard-xpack-monitoring). 
+The [trial license](https://www.elastic.co/guide/en/elasticsearch/reference/current/license-settings.html) is valid 
+for 30 days.
 
 It will give you the ability to analyze any data set by using the searching/aggregation capabilities of Elasticsearch
 and the visualization power of Kibana.
@@ -23,6 +28,7 @@ Default configuration of Search Guard in this repo is:
 * HTTPS disabled
 * Hostname verification disabled
 * Self-signed SSL certificate for transport protocol (do not use in production)
+* Enable monitoring permissions for Logstash
 
 **Check the [Demo users and roles](http://docs.search-guard.com/latest/demo-users-roles) documentation page for a list
 and description of the built-in Search Guard users.**

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -25,3 +25,7 @@ searchguard.ssl.transport.enforce_hostname_verification: false
 
 searchguard.authcz.admin_dn:
   - "CN=kirk,OU=client,O=client,l=tEst,C=De"
+
+xpack.license.self_generated.type: trial
+xpack.security.enabled: false
+xpack.monitoring.enabled: true

--- a/elasticsearch/config/sg/sg_roles.yml
+++ b/elasticsearch/config/sg/sg_roles.yml
@@ -108,6 +108,7 @@ sg_logstash:
   cluster:
     - CLUSTER_MONITOR
     - CLUSTER_COMPOSITE_OPS
+    - cluster:admin/xpack/monitoring*
     - indices:admin/template/get
     - indices:admin/template/put
   indices:
@@ -115,6 +116,9 @@ sg_logstash:
       '*':
         - CRUD
         - CREATE_INDEX
+    '?monitoring*':
+      '*':
+        - INDICES_ALL
     '*beat*':
       '*':
         - CRUD

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -5,6 +5,8 @@
 server.name: kibana
 server.host: "0"
 elasticsearch.url: http://elasticsearch:9200
+xpack.monitoring.ui.container.elasticsearch.enabled: true
+xpack.security.enabled: false
 
 ## Custom configuration
 #

--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -4,3 +4,7 @@
 #
 http.host: "0.0.0.0"
 path.config: /usr/share/logstash/pipeline
+xpack.monitoring.enabled: true
+xpack.monitoring.elasticsearch.hosts: ['http://elasticsearch:9200']
+xpack.monitoring.elasticsearch.username: logstash
+xpack.monitoring.elasticsearch.password: logstash


### PR DESCRIPTION

- [Search Guard support](https://github.com/floragunncom/search-guard)

- [X-Pack support](https://www.elastic.co/products/x-pack) with [X-Packsecurity](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html) disable because it is managed by [Search Guard](https://docs.search-guard.com/latest/search-guard-xpack-monitoring). X-Pack monitoring fully working.

The [trial license](https://www.elastic.co/guide/en/elasticsearch/reference/current/license-settings.html) is valid for 30 days.