### PR TITLE
Updated the logstash.yml to run on the docker-composer up command

### DIFF
--- a/logstash/config/logstash.yml
+++ b/logstash/config/logstash.yml
@@ -7,6 +7,5 @@ xpack.monitoring.elasticsearch.url: http://elasticsearch:9200
 
 ## X-Pack security credentials
 #
-xpack.monitoring.elasticsearch.username: logstash_system
-xpack.monitoring.elasticsearch.password: changeme  # unset by default. see:
-                                                   # https://www.elastic.co/guide/en/logstash/current/ls-security.html#ls-monitoring-user
+xpack.monitoring.elasticsearch.username: elastic
+xpack.monitoring.elasticsearch.password: changeme


### PR DESCRIPTION
Without this changes, the logstash can't run properly, returning 401 when running the `docker-compose up`.
This pull request changes the logstash.yml configuration to use the `elastic` user with the `changeme` password