### PR TITLE
Fix conflict between x-pack and SG

### DIFF
--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -25,3 +25,5 @@ searchguard.ssl.transport.enforce_hostname_verification: false
 
 searchguard.authcz.admin_dn:
   - "CN=kirk,OU=client,O=client,l=tEst,C=De"
+
+xpack.security.enabled: false

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -12,3 +12,5 @@ elasticsearch.username: "kibanaserver"
 elasticsearch.password: "kibanaserver"
 
 searchguard.cookie.password: "123567818187654rwrwfsfshdhdhtegdhfzftdhncn"
+
+xpack.security.enabled: false


### PR DESCRIPTION
After upgrade, I got this issue `Cannot have additional setting [http.type] in plugin [search-guard-ssl], already added in plugin [x-pack]`

Disabling the x-pack security fixing it
https://github.com/floragunncom/search-guard-ssl/issues/43