### PR TITLE
updating xpack credentials to v7.X.X

### DIFF
--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -9,5 +9,5 @@ xpack.monitoring.ui.container.elasticsearch.enabled: true
 
 ## X-Pack security credentials
 #
-elasticsearch.username: elastic
-elasticsearch.password: changeme
+xpack.monitoring.elasticsearch.username: elastic
+xpack.monitoring.elasticsearch.password: changeme

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -9,5 +9,7 @@ xpack.monitoring.ui.container.elasticsearch.enabled: true
 
 ## X-Pack security credentials
 #
+elasticsearch.username: elastic
+elasticsearch.password: changeme
 xpack.monitoring.elasticsearch.username: elastic
 xpack.monitoring.elasticsearch.password: changeme


### PR DESCRIPTION
v7 requires slightly different syntax of the xpack security credentials to connect. `elasticsearch.username` and `elasticsearch.password` results in kibana errors not being able to authenticate. Kibana webpage continues to say "Kibana server is not ready yet" while producing the auth errors. Tested on Kibana 7.0.1