### PR TITLE
Use v3 volume syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Other available stack variants:
 
 ### Host setup
 
-* [Docker](https://www.docker.com/community-edition#/download) version **17.05+**
-* [Docker Compose](https://docs.docker.com/compose/install/) version **1.6.0+**
+* [Docker Engine](https://docs.docker.com/install/) version **17.05+**
+* [Docker Compose](https://docs.docker.com/compose/install/) version **1.12.0+**
 * 1.5 GB of RAM
 
 By default, the stack exposes the following ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.2'
 
 services:
 
@@ -8,7 +8,10 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     volumes:
-      - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+      - type: bind
+        source: ./elasticsearch/config/elasticsearch.yml
+        target: /usr/share/elasticsearch/config/elasticsearch.yml
+        read_only: true
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -24,8 +27,14 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     volumes:
-      - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro
-      - ./logstash/pipeline:/usr/share/logstash/pipeline:ro
+      - type: bind
+        source: ./logstash/config/logstash.yml
+        target: /usr/share/logstash/config/logstash.yml
+        read_only: true
+      - type: bind
+        source: ./logstash/pipeline
+        target: /usr/share/logstash/pipeline
+        read_only: true
     ports:
       - "5000:5000"
       - "9600:9600"
@@ -42,7 +51,10 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     volumes:
-      - ./kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
+      - type: bind
+        source: ./kibana/config/kibana.yml
+        target: /usr/share/kibana/config/kibana.yml
+        read_only: true
     ports:
       - "5601:5601"
     networks:


### PR DESCRIPTION
The Compose v3 format uses a volumes syntax which is more explicit and IMO easier to understand than the v2 long colon-separated string.

It is supported since:
* [Docker 17.04.0](https://docs.docker.com/compose/compose-file/#compose-and-docker-compatibility-matrix)
    We already require 17.05.0 in the README to support the `.env` input file.
* [Compose 1.12.0](https://github.com/docker/compose/releases/tag/1.12.0)
    We need to bump our requirement, but that version was released in April 2017.

@deviantony do you think it's sensible?