### PR TITLE
Update Dockerfile to use latest curator

### DIFF
--- a/extensions/curator/Dockerfile
+++ b/extensions/curator/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV CURATOR_VERSION=5.5.4
+ENV CURATOR_VERSION=5.8.1
 
 RUN apk --update add --no-cache tini python py-pip \
   && pip install elasticsearch-curator==${CURATOR_VERSION}


### PR DESCRIPTION
Otherwise it fails with this exception:
`elasticsearch.exceptions.ElasticsearchException: Unable to create client connection to Elasticsearch.  Error: Elasticsearch version 7.4.1 incompatible with this version of Curator (5.5.4)`