### PR TITLE
Open udp logstash port 5000  for logspout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,8 @@ services:
         target: /usr/share/logstash/pipeline
         read_only: true
     ports:
-      - "5000:5000"
+      - "5000:5000/tcp"
+      - "5000:5000/udp"
       - "9600:9600"
     environment:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"


### PR DESCRIPTION
Hey! Thanks for your great repo on elk!
Had an issue when installing the logspout extension. We use udp to send data to logstash, but the port is opened only for tcp connections. This PR fixes that 