### PR TITLE
Allowing the admin user to access SearchGuard GUI

### DIFF
--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -21,3 +21,4 @@ searchguard.ssl.transport.enforce_hostname_verification: false
 
 searchguard.authcz.admin_dn:
   - "CN=kirk,OU=client,O=client,l=tEst,C=De"
+ searchguard.restapi.roles_enabled: ["SGS_ALL_ACCESS"]

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -21,4 +21,4 @@ searchguard.ssl.transport.enforce_hostname_verification: false
 
 searchguard.authcz.admin_dn:
   - "CN=kirk,OU=client,O=client,l=tEst,C=De"
- searchguard.restapi.roles_enabled: ["SGS_ALL_ACCESS"]
+searchguard.restapi.roles_enabled: ["SGS_ALL_ACCESS"]

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -20,5 +20,7 @@ searchguard.ssl.transport.truststore_filepath: sg/truststore.jks
 searchguard.ssl.transport.enforce_hostname_verification: false
 
 searchguard.authcz.admin_dn:
-  - "CN=kirk,OU=client,O=client,l=tEst,C=De"
-searchguard.restapi.roles_enabled: ["SGS_ALL_ACCESS"]
+  - CN=kirk,OU=client,O=client,l=tEst,C=De
+
+searchguard.restapi.roles_enabled:
+  - SGS_ALL_ACCESS


### PR DESCRIPTION
Allowing the admin (user) to access Search Guard configuration GUI from kibana ! 
without this entry in the elasticsearch.yml the sg icon diapers from the left menu.