### PR TITLE
relaced single quota to double quota in docker-compose.yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: "3.2"
 
 services:
   elasticsearch:


### PR DESCRIPTION
When I wanted to start docker-compose the services, it returned a lots of errors and traces, I think the bottom line is the most relevant: 
`docker.errors.DockerException: Error while fetching server API version: '<' not supported between instances of 'Retry' and 'int'`
After I searched for this error message, found the problem and solution, which is to replace single quotes to double ones, and it solved the issue.

I experienced the same problem on Arch linux / docker compose 1.27.3 / docker 19.03.13-ce,
and debian buster/sid 1.17.1 / docker 19.03.13

I hope it helps