### PR TITLE
Proposal: rename master branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # At 00:00 every Sunday
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Elastic stack (ELK) on Docker
 
 [![Elastic Stack version](https://img.shields.io/badge/Elastic%20Stack-7.10.2-00bfb3?style=flat&logo=elastic-stack)](https://www.elastic.co/blog/category/releases)
-[![Build Status](https://github.com/deviantony/docker-elk/workflows/CI/badge.svg?branch=master)](https://github.com/deviantony/docker-elk/actions?query=workflow%3ACI+branch%3Amaster)
+[![Build Status](https://github.com/deviantony/docker-elk/workflows/CI/badge.svg?branch=main)](https://github.com/deviantony/docker-elk/actions?query=workflow%3ACI+branch%3Amain)
 [![Join the chat at https://gitter.im/deviantony/docker-elk](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/deviantony/docker-elk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Run the latest version of the [Elastic stack][elk-stack] with Docker and Docker Compose.
@@ -121,8 +121,8 @@ exclusively. Make sure the repository is cloned in one of those locations or fol
 
 ### Version selection
 
-This repository tries to stay aligned with the latest version of the Elastic stack. The `master` branch tracks the
-current major version (7.x).
+This repository tries to stay aligned with the latest version of the Elastic stack. The `main` branch tracks the current
+major version (7.x).
 
 To use a different version of the core Elastic components, simply change the version number inside the `.env` file. If
 you are upgrading an existing stack, please carefully read the note in the next section.


### PR DESCRIPTION
In an effort to reduce the usage of divisive language, GitHub has recently renamed the default Git branch from `master` to `main` for new projects, and some open-source projects are starting to catch up by renaming their default branch as well.

It would be effortless to do it in `docker-elk` because GitHub takes care of re-targeting everything to `main` seamlessly, including existing clones (with a notice printed in the terminal), as explained at https://github.com/github/renaming#renaming-existing-branches.

Considering the popularity of this project, I think this move would be generally welcomed. @deviantony what do you think?
If you approve this, you will also need to actually rename the branch at https://github.com/deviantony/docker-elk/branches before merging.

---

Examples:

```console
$ git push
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 177 bytes | 177.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0)
remote:
remote: Heads up! The branch 'master' that you pushed to was renamed to 'main'.
remote:
To github.com:antoineco/docker-elk.git
```

![image](https://user-images.githubusercontent.com/3299086/105065545-441c0c00-5a7e-11eb-9dfe-22af9270768b.png)