### PR TITLE
Use token from GitHub App in auto-update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -82,10 +82,19 @@ jobs:
               echo '::set-output name=has_changes::true'
           fi
 
+      - name: Impersonate update bot
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        if: steps.update-files.outputs.has_changes
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Send pull request to update to new version
         if: steps.update-files.outputs.has_changes
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           branch: update/${{ matrix.branch }}
           commit-message: Update to v${{ fromJson(steps.get-latest-release.outputs.result).version }}
           title: Update to v${{ fromJson(steps.get-latest-release.outputs.result).version }}


### PR DESCRIPTION
Per the instructions found at [Authenticating with GitHub App generated tokens](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens).

Requires the `docker-elk Updater` app referenced by `{{ secrets.APP_ID }}` to be first installed in the repo.

Example of PR generated by impersonating the app: https://github.com/antoineco/docker-elk/pull/19

Closes #552 