### PR TITLE
Podman and SELinux compatible volume declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ own_. [sherifabdlnaby/elastdocker][elastdocker] is one example among others of p
 
 1. [Requirements](#requirements)
    * [Host setup](#host-setup)
-   * [SELinux](#selinux)
    * [Docker Desktop](#docker-desktop)
      * [Windows](#windows)
      * [macOS](#macos)
@@ -96,16 +95,6 @@ By default, the stack exposes the following ports:
 **:warning: Elasticsearch's [bootstrap checks][booststap-checks] were purposely disabled to facilitate the setup of the
 Elastic stack in development environments. For production setups, we recommend users to set up their host according to
 the instructions from the Elasticsearch documentation: [Important System Configuration][es-sys-config].**
-
-### SELinux
-
-On distributions which have SELinux enabled out-of-the-box you will need to either re-context the files or set SELinux
-into Permissive mode in order for docker-elk to start properly. For example on Redhat and CentOS, the following will
-apply the proper context:
-
-```console
-$ chcon -R system_u:object_r:admin_home_t:s0 docker-elk/
-```
 
 ### Docker Desktop
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,7 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     volumes:
-      - type: bind
-        source: ./elasticsearch/config/elasticsearch.yml
-        target: /usr/share/elasticsearch/config/elasticsearch.yml
-        read_only: true
+      - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,z
       - type: volume
         source: elasticsearch
         target: /usr/share/elasticsearch/data
@@ -32,14 +29,8 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     volumes:
-      - type: bind
-        source: ./logstash/config/logstash.yml
-        target: /usr/share/logstash/config/logstash.yml
-        read_only: true
-      - type: bind
-        source: ./logstash/pipeline
-        target: /usr/share/logstash/pipeline
-        read_only: true
+      - ./logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,z
+      - ./logstash/pipeline:/usr/share/logstash/pipeline:ro,z
     ports:
       - "5044:5044"
       - "5000:5000/tcp"
@@ -58,10 +49,7 @@ services:
       args:
         ELK_VERSION: $ELK_VERSION
     volumes:
-      - type: bind
-        source: ./kibana/config/kibana.yml
-        target: /usr/share/kibana/config/kibana.yml
-        read_only: true
+      - ./kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro,z
     ports:
       - "5601:5601"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,7 @@ services:
         ELK_VERSION: $ELK_VERSION
     volumes:
       - ./elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,z
-      - type: volume
-        source: elasticsearch
-        target: /usr/share/elasticsearch/data
+      - elasticsearch:/usr/share/elasticsearch/data:z
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
While running on Fedora 34, with podman-compose and SELinux enabled, I was getting permission errors.

[Based on this discussion](https://github.com/containers/podman-compose/issues/256), it seems compose file doesn't allow setting [SELinux label](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label) on the long syntax, so I changed the bindings to the short format.

Errors before changes:

```
2021/11/25 00:27:29 error: open /usr/share/logstash/config/logstash.yml: permission denied
1
podman start -a docker-elk_kibana_1
internal/fs/utils.js:332
    throw err;
    ^

Error: EACCES: permission denied, open '/usr/share/kibana/config/kibana.yml'
    at Object.openSync (fs.js:497:3)
    at readFileSync (fs.js:393:35)
    at readYaml (/usr/share/kibana/node_modules/@kbn/apm-config-loader/target_node/utils/read_config.js:25:69)
    at getConfigFromFiles (/usr/share/kibana/node_modules/@kbn/apm-config-loader/target_node/utils/read_config.js:57:18)
    at loadConfiguration (/usr/share/kibana/node_modules/@kbn/apm-config-loader/target_node/config_loader.js:30:58)
    at initApm (/usr/share/kibana/node_modules/@kbn/apm-config-loader/target_node/init_apm.js:18:64)
    at module.exports (/usr/share/kibana/src/cli/apm.js:27:3)
    at Object.<anonymous> (/usr/share/kibana/src/cli/dist.js:10:17)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10) {
  errno: -13,
  syscall: 'open',
  code: 'EACCES',
  path: '/usr/share/kibana/config/kibana.yml'
}
1
Exception in thread "main" SettingsException[Failed to load settings from /usr/share/elasticsearch/config/elasticsearch.yml]; nested: AccessDeniedException[/usr/share/elasticsearch/config/elasticsearch.yml];
	at org.elasticsearch.node.InternalSettingsPreparer.prepareEnvironment(InternalSettingsPreparer.java:74)
	at org.elasticsearch.cli.EnvironmentAwareCommand.createEnv(EnvironmentAwareCommand.java:89)
	at org.elasticsearch.cli.EnvironmentAwareCommand.createEnv(EnvironmentAwareCommand.java:80)
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:75)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:114)
	at org.elasticsearch.cli.MultiCommand.execute(MultiCommand.java:95)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:114)
	at org.elasticsearch.cli.Command.main(Command.java:79)
	at org.elasticsearch.common.settings.KeyStoreCli.main(KeyStoreCli.java:32)
Caused by: java.nio.file.AccessDeniedException: /usr/share/elasticsearch/config/elasticsearch.yml
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:422)
	at java.base/java.nio.file.Files.newInputStream(Files.java:160)
	at org.elasticsearch.common.settings.Settings$Builder.loadFromPath(Settings.java:1082)
	at org.elasticsearch.node.InternalSettingsPreparer.prepareEnvironment(InternalSettingsPreparer.java:72)
	... 8 more
1
```

![image](https://user-images.githubusercontent.com/8113764/143328935-0f45ab95-5e57-4183-ab4e-836edaac4346.png)