### PR TITLE
Remove quotes from passwords

### DIFF
--- a/.env
+++ b/.env
@@ -7,16 +7,16 @@ ELASTIC_VERSION=8.0.0
 #
 # Superuser role, full access to cluster management and data indices.
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html
-ELASTIC_PASSWORD='changeme'
+ELASTIC_PASSWORD=changeme
 
 # User 'logstash_internal' (custom)
 #
 # The user Logstash uses to connect and send data to Elasticsearch.
 # https://www.elastic.co/guide/en/logstash/current/ls-security.html
-LOGSTASH_INTERNAL_PASSWORD='changeme'
+LOGSTASH_INTERNAL_PASSWORD=changeme
 
 # User 'kibana_system' (built-in)
 #
 # The user Kibana uses to connect and communicate with Elasticsearch.
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html
-KIBANA_SYSTEM_PASSWORD='changeme'
+KIBANA_SYSTEM_PASSWORD=changeme


### PR DESCRIPTION
In my environment default passwords don't work because single quotes are not removed.
So the password for Kibana web UI is `'changeme'` but it should be `changeme` as explained in the README

Environment:
Ubuntu 20.04.3 LTS
docker-compose version 1.25.0
Docker version 20.10.7