### PR TITLE
feat: healthcheck for elasticsearch and kibana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-}
     networks:
       - elk
+      
 
   elasticsearch:
     build:
@@ -46,6 +47,15 @@ services:
       discovery.type: single-node
     networks:
       - elk
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s http://localhost:9200 | grep -q 'missing authentication credentials'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
 
   logstash:
     build:
@@ -82,7 +92,17 @@ services:
     networks:
       - elk
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
 
 networks:
   elk:


### PR DESCRIPTION
Referring to [get-started-stack-docker](https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-stack-docker.html#docker-compose-file), added healthcheck for elasticsearch and kibana, and ensured that kibana starts after elasticsearch

