### PR TITLE
Update entrypoint.sh

### DIFF
--- a/setup/entrypoint.sh
+++ b/setup/entrypoint.sh
@@ -18,6 +18,7 @@ users_passwords=(
 declare -A users_roles
 users_roles=(
 	[logstash_internal]='logstash_writer'
+	[kibana_system]='kibana_system'
 )
 
 # --------------------------------------------------------


### PR DESCRIPTION
Commit https://github.com/deviantony/docker-elk/commit/9877b39900076a764036352b331a6115adc91c87#r77273964  broke creating kibana_system user.
This patch fix it.

> docker compose up -d elasticsearch
> docker compose up setup

```
docker-elk-setup-1  | -------- Wed Jun 29 12:33:51 UTC 2022 --------
docker-elk-setup-1  | [+] Waiting for availability of Elasticsearch. This can take several minutes.
docker-elk-setup-1  |    ⠿ Elasticsearch is running
docker-elk-setup-1  | [+] Role 'logstash_writer'
docker-elk-setup-1  |    ⠿ Creating/updating
docker-elk-setup-1  | [+] User 'kibana_system'
docker-elk-setup-1  | [+] User 'logstash_internal'
docker-elk-setup-1  | [x]   No role defined, skipping creation
```
As result we got not working Kibana.

This patch fix issue and user logstash_internal
It use the default built-in role

https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-roles.html

