### PR TITLE
fix #739 Mac OS Monterey logstash port conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
           # Set mandatory Logstash settings
 
-          sed -i '$ a input { udp { port => 5000 codec => json } }' logstash/pipeline/logstash.conf
+          sed -i '$ a input { udp { port => 50000 codec => json } }' logstash/pipeline/logstash.conf
 
           # Restart Logstash for changes to take effect
 
@@ -102,7 +102,7 @@ jobs:
 
           # Revert changes to Logstash configuration
 
-          sed -i '/input { udp { port => 5000 codec => json } }/d' logstash/pipeline/logstash.conf
+          sed -i '/input { udp { port => 50000 codec => json } }/d' logstash/pipeline/logstash.conf
           docker compose restart logstash
 
       - name: 'debug: Display state and logs (Logspout)'

--- a/.github/workflows/scripts/run-tests-core.sh
+++ b/.github/workflows/scripts/run-tests-core.sh
@@ -30,7 +30,7 @@ declare -i was_retried=0
 
 # retry for max 10s (5*2s)
 for _ in $(seq 1 5); do
-	if echo 'dockerelk' | nc -q0 "$ip_ls" 5000; then
+	if echo 'dockerelk' | nc -q0 "$ip_ls" 50000; then
 		break
 	fi
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ own_. [sherifabdlnaby/elastdocker][elastdocker] is one example among others of p
 By default, the stack exposes the following ports:
 
 * 5044: Logstash Beats input
-* 5000: Logstash TCP input
+* 50000: Logstash TCP input
 * 9600: Logstash monitoring API
 * 9200: Elasticsearch HTTP
 * 9300: Elasticsearch TCP transport
@@ -221,12 +221,12 @@ allows you to send content via TCP:
 
 ```console
 # Using BSD netcat (Debian, Ubuntu, MacOS system, ...)
-$ cat /path/to/logfile.log | nc -q0 localhost 5000
+$ cat /path/to/logfile.log | nc -q0 localhost 50000
 ```
 
 ```console
 # Using GNU netcat (CentOS, Fedora, MacOS Homebrew, ...)
-$ cat /path/to/logfile.log | nc -c localhost 5000
+$ cat /path/to/logfile.log | nc -c localhost 50000
 ```
 
 You can also load the sample data provided by your Kibana installation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,8 @@ services:
       - ./logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
     ports:
       - "5044:5044"
-      - "5000:5000/tcp"
-      - "5000:5000/udp"
+      - "50000:50000/tcp"
+      - "50000:50000/udp"
       - "9600:9600"
     environment:
       LS_JAVA_OPTS: -Xms256m -Xmx256m

--- a/extensions/logspout/README.md
+++ b/extensions/logspout/README.md
@@ -17,7 +17,7 @@ In your Logstash pipeline configuration, enable the `udp` input and set the inpu
 ```logstash
 input {
   udp {
-    port  => 5000
+    port  => 50000
     codec => json
   }
 }

--- a/extensions/logspout/logspout-compose.yml
+++ b/extensions/logspout/logspout-compose.yml
@@ -10,7 +10,7 @@ services:
         target: /var/run/docker.sock
         read_only: true
     environment:
-      ROUTE_URIS: logstash://logstash:5000
+      ROUTE_URIS: logstash://logstash:50000
       LOGSTASH_TAGS: docker-elk
     networks:
       - elk

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -4,7 +4,7 @@ input {
 	}
 
 	tcp {
-		port => 5000
+		port => 50000
 	}
 }
 


### PR DESCRIPTION
Mac OS Monterey is having an airplay server listening on port 5000, recommended fix is to change log stash's default listening port from 5000 to 50000 ( add one more zero) to resolve the conflict.

edit (@antoineco): fixes #739