### PR TITLE
Add example of Fleet-enrolled APM Server agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           -f docker-compose.yml
           -f extensions/logspout/logspout-compose.yml
           -f extensions/fleet/fleet-compose.yml
+          -f extensions/fleet/agent-apmserver-compose.yml
           -f extensions/metricbeat/metricbeat-compose.yml
           -f extensions/filebeat/filebeat-compose.yml
           -f extensions/heartbeat/heartbeat-compose.yml
@@ -122,14 +123,15 @@ jobs:
 
       - name: Execute Fleet test suite
         run: |
-          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml up --remove-orphans -d fleet-server
+          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml -f extensions/fleet/agent-apmserver-compose.yml up --remove-orphans -d fleet-server apm-server
           .github/workflows/scripts/run-tests-fleet.sh
 
       - name: 'debug: Display state and logs (Fleet)'
         if: always()
         run: |
-          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml ps
-          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml logs fleet-server
+          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml -f extensions/fleet/agent-apmserver-compose.yml ps
+          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml -f extensions/fleet/agent-apmserver-compose.yml logs fleet-server
+          docker compose -f docker-compose.yml -f extensions/fleet/fleet-compose.yml -f extensions/fleet/agent-apmserver-compose.yml logs apm-server
 
       #
       # Metricbeat
@@ -216,6 +218,7 @@ jobs:
           -f docker-compose.yml
           -f extensions/logspout/logspout-compose.yml
           -f extensions/fleet/fleet-compose.yml
+          -f extensions/fleet/agent-apmserver-compose.yml
           -f extensions/metricbeat/metricbeat-compose.yml
           -f extensions/filebeat/filebeat-compose.yml
           -f extensions/heartbeat/heartbeat-compose.yml

--- a/.github/workflows/scripts/run-tests-fleet.sh
+++ b/.github/workflows/scripts/run-tests-fleet.sh
@@ -9,15 +9,20 @@ source "$(dirname ${BASH_SOURCE[0]})/lib/testing.sh"
 
 cid_es="$(container_id elasticsearch)"
 cid_fl="$(container_id fleet-server)"
+cid_apm="$(container_id apm-server)"
 
 ip_es="$(service_ip elasticsearch)"
 ip_fl="$(service_ip fleet-server)"
+ip_apm="$(service_ip apm-server)"
 
 log 'Waiting for readiness of Elasticsearch'
 poll_ready "$cid_es" "http://${ip_es}:9200/" -u 'elastic:testpasswd'
 
 log 'Waiting for readiness of Fleet Server'
 poll_ready "$cid_fl" "http://${ip_fl}:8220/api/status"
+
+log 'Waiting for readiness of APM Server'
+poll_ready "$cid_apm" "http://${ip_apm}:8200/"
 
 # We expect to find metrics entries using the following query:
 #

--- a/extensions/fleet/agent-apmserver-compose.yml
+++ b/extensions/fleet/agent-apmserver-compose.yml
@@ -1,0 +1,45 @@
+version: '3.7'
+
+# Example of Fleet-enrolled Elastic Agent pre-configured with an agent policy
+# for running the APM Server integration (see kibana.yml).
+#
+# Run with
+#   docker-compose \
+#     -f docker-compose.yml \
+#     -f extensions/fleet/fleet-compose.yml \
+#     -f extensions/fleet/agent-apmserver-compose.yml \
+#     up
+
+services:
+  apm-server:
+    build:
+      context: extensions/fleet/
+      args:
+        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    volumes:
+      - apm-server:/usr/share/elastic-agent/state:z
+    environment:
+      FLEET_ENROLL: '1'
+      FLEET_TOKEN_POLICY_NAME: Agent Policy APM Server
+      FLEET_INSECURE: '1'
+      FLEET_URL: http://fleet-server:8220
+      # Enrollment.
+      # (a) Auto-enroll using basic authentication
+      ELASTICSEARCH_USERNAME: elastic
+      ELASTICSEARCH_PASSWORD: ${ELASTIC_PASSWORD:-}
+      # (b) Enroll using a pre-generated enrollment token
+      #FLEET_ENROLLMENT_TOKEN: <enrollment_token>
+    ports:
+      - 8200:8200
+    hostname: apm-server
+    # Elastic Agent does not retry failed connections to Kibana upon the initial enrollment phase.
+    restart: on-failure
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+      - kibana
+      - fleet-server
+
+volumes:
+  apm-server:

--- a/extensions/fleet/fleet-compose.yml
+++ b/extensions/fleet/fleet-compose.yml
@@ -10,7 +10,7 @@ services:
       - fleet-server:/usr/share/elastic-agent/state:z
     environment:
       FLEET_SERVER_ENABLE: '1'
-      FLEET_SERVER_INSECURE_HTTP: 'true'
+      FLEET_SERVER_INSECURE_HTTP: '1'
       FLEET_SERVER_POLICY_ID: fleet-server-policy
       # Fleet plugin in Kibana
       KIBANA_FLEET_SETUP: '1'
@@ -21,7 +21,7 @@ services:
       # (b) Enroll using a pre-generated service token
       #FLEET_SERVER_SERVICE_TOKEN: <service_token>
     ports:
-      - '8220:8220'
+      - 8220:8220
     hostname: fleet-server
     # Elastic Agent does not retry failed connections to Kibana upon the initial enrollment phase.
     restart: on-failure

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -32,11 +32,13 @@ xpack.fleet.packages:
     version: latest
   - name: elastic_agent
     version: latest
+  - name: apm
+    version: latest
 
 xpack.fleet.agentPolicies:
-  - name: Fleet Server policy
+  - name: Fleet Server Policy
     id: fleet-server-policy
-    description: Fleet Server policy
+    description: Static agent policy for Fleet Server
     monitoring_enabled:
       - logs
       - metrics
@@ -50,3 +52,28 @@ xpack.fleet.agentPolicies:
       - name: elastic_agent-1
         package:
           name: elastic_agent
+  - name: Agent Policy APM Server
+    id: agent-policy-apm-server
+    description: Static agent policy for the APM Server integration
+    monitoring_enabled:
+      - logs
+      - metrics
+    package_policies:
+      - name: system-1
+        package:
+          name: system
+      - name: elastic_agent-1
+        package:
+          name: elastic_agent
+      - name: apm-1
+        package:
+          name: apm
+        # See the APM package manifest for a list of possible inputs.
+        # https://github.com/elastic/apm-server/blob/v8.5.0/apmpackage/apm/manifest.yml#L41-L168
+        inputs:
+          - type: apm
+            vars:
+              - name: host
+                value: 0.0.0.0:8200
+              - name: url
+                value: http://apm-server:8200


### PR DESCRIPTION
Closes #773

Ref #756
Ref #761

---

~Marking as draft, I am not yet convinced we should enable this by default.
We could ship commented configurations instead, but this is messy.
It would be ideal to have an enabled/disabled flag for additional integrations such as APM Server, but Fleet doesn't have a notion of disabled integrations within agent policies.~

I repurposed the PR to enable APM Server in a separate Fleet-enrolled Elastic Agent, instead of inside the Fleet Server itself.