### PR TITLE
ci: Set Compose project name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     # List of supported runners:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: ubuntu-22.04
+
     env:
       COMPOSE_PROJECT_NAME: docker-elk
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     # List of supported runners:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: ubuntu-22.04
+    env:
+      COMPOSE_PROJECT_NAME: docker-elk
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Avoids failures while determining container IPs when the project isn't checked out in a directory named "docker-elk".

Fixes #839