### PR TITLE
Add Kibana health-check to avoid Fleet's "service_token" request errors. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,12 @@ services:
       - elk
     depends_on:
       - elasticsearch
+    healthcheck:
+      test: curl -f http://localhost:5601 || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
     restart: unless-stopped
 
 networks:

--- a/extensions/fleet/fleet-compose.yml
+++ b/extensions/fleet/fleet-compose.yml
@@ -29,8 +29,9 @@ services:
     networks:
       - elk
     depends_on:
-      - elasticsearch
-      - kibana
+      kibana:
+        condition: service_healthy
+        restart: true
 
 volumes:
   fleet-server:


### PR DESCRIPTION
When deploying Fleet along the base stack, the fleet server tries to get a `service_token` from Kibana immediately, which slows down the deployment and makes a very noisy log with multiple `fleet-server` errors and retries. Adding this health-check, `fleet-server` will wait until Kibana has reached the `service_healthy` status.