### PR TITLE
Updated Readme.md (First pull request)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ variable, allowing the user to adjust the amount of memory that can be used by e
 | Elasticsearch | ES_JAVA_OPTS         |
 | Logstash      | LS_JAVA_OPTS         |
 
-To accomodate environments where memory is scarce (Docker Desktop for Mac has only 2 GB available by default), the Heap
+To accommodate environments where memory is scarce (Docker Desktop for Mac has only 2 GB available by default), the Heap
 Size allocation is capped by default in the `docker-compose.yml` file to 512 MB for Elasticsearch and 256 MB for
 Logstash. If you want to override the default JVM configuration, edit the matching environment variable(s) in the
 `docker-compose.yml` file.


### PR DESCRIPTION
Fixed a typo error in the Readme file. the  word "accomodate" was changed to "accommadate".