### PR TITLE
copy entrypoint script inside setup image

### DIFF
--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -2,5 +2,5 @@ ARG ELASTIC_VERSION
 
 # https://www.docker.elastic.co/
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
-
+COPY entrypoint.sh entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This is fix is needed since the entrypoint.sh script is missing (I added a RUN ls / before the ENTRYPOINT directive)

```
------
 > [setup 2/2] RUN ls /
0.190 bin
0.190 boot
0.190 dev
0.190 etc
0.190 home
0.190 lib
0.190 lib32
0.190 lib64
0.190 libx32
0.190 media
0.190 mnt
0.190 opt
0.190 proc
0.190 root
0.190 run
0.190 sbin
0.190 srv
0.190 sys
0.190 tmp
0.190 usr
0.190 var
```