### PR TITLE
Add kibana_system role to users_roles array

### DIFF
--- a/setup/entrypoint.sh
+++ b/setup/entrypoint.sh
@@ -23,6 +23,7 @@ users_passwords=(
 declare -A users_roles
 users_roles=(
 	[logstash_internal]='logstash_writer'
+	[kibana_system]='kibana_system'
 	[metricbeat_internal]='metricbeat_writer'
 	[filebeat_internal]='filebeat_writer'
 	[heartbeat_internal]='heartbeat_writer'


### PR DESCRIPTION
# Fix: Allow `kibana_system` password update in docker-compose setup

## Problem
When using `docker-compose up setup` to update the `kibana_system` password in an existing ELK cluster, the password was not applied correctly.  
The logs show:

Instead of updating the password like `logstash_internal`:

This issue is caused by `kibana_system` not being assigned a role in the `users_roles` array.

---

## Solution
Add `kibana_system` to the `users_roles` array:

```bash
users_roles=(
  [logstash_internal]='logstash_internal'
  [kibana_system]='kibana_system'  # Fix password update issue
  # other users...
)

[+] User 'kibana_system'
⠿ User exists, setting password

---
If you like, I can add a ** more concise Chinese version ** of the description to make it easier for domestic open source project maintainers to understand it quickly. Do you want me to add it?